### PR TITLE
kodiPlugins.pvr-hts: update to 3.4.4 for kodi17

### DIFF
--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -6,14 +6,14 @@ let
 
   kodi-platform = stdenv.mkDerivation rec {
     project = "kodi-platform";
-    version = "15.2";
+    version = "17.1";
     name = "${project}-${version}";
 
     src = fetchFromGitHub {
       owner = "xbmc";
       repo = project;
-      rev = "45d6ad1984fdb1dc855076ff18484dbec33939d1";
-      sha256 = "1fai33mwyv5ab47b16i692g7a3vcnmxavx13xin2gh16y0qm62hi";
+      rev = "c8188d82678fec6b784597db69a68e74ff4986b5";
+      sha256 = "1r3gs3c6zczmm66qcxh9mr306clwb3p7ykzb70r3jv5jqggiz199";
     };
 
     buildInputs = [ cmake kodi libcec_platform tinyxml ];
@@ -219,13 +219,13 @@ in
   pvr-hts = (mkKodiPlugin rec {
     plugin = "pvr-hts";
     namespace = "pvr.hts";
-    version = "2.2.13";
+    version = "3.4.4";
 
     src = fetchFromGitHub {
       owner = "kodi-pvr";
       repo = "pvr.hts";
-      rev = "3274354511e970e2101c2aa437001b2f245f80da";
-      sha256 = "0i7cb61pjv6vbj3x96cm1n4w91mvc8z6lxa8ykjasrrbi95ph7ld";
+      rev = "343ca980982d87c778696e42e52eff763cadee4a";
+      sha256 = "03jk45nk1c5j7zwj6l8s8jyf6ijhisp1r16xg6n5561bm3cfk0b9";
     };
 
     meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libcec/default.nix
+++ b/pkgs/development/libraries/libcec/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, cmake, pkgconfig, udev, libcec_platform }:
 
-let version = "3.0.1"; in
+let version = "3.1.0"; in
 
 stdenv.mkDerivation {
   name = "libcec-${version}";
 
   src = fetchurl {
     url = "https://github.com/Pulse-Eight/libcec/archive/libcec-${version}.tar.gz";
-    sha256 = "0gi5gq8pz6vfdx80pimx23d5g243zzgmc7s8wpb686csjk470dky";
+    sha256 = "08gr4rhx7qh8ajkry9j0sqw11i74y802dla1wg4l4gxhl4hrs409";
   };
 
   buildInputs = [ cmake pkgconfig udev libcec_platform ];

--- a/pkgs/development/libraries/libcec/platform.nix
+++ b/pkgs/development/libraries/libcec/platform.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, cmake }:
 
-let version = "1.0.10"; in
+let version = "2.0.1"; in
 
 stdenv.mkDerivation {
-  name = "libcec-${version}";
+  name = "p8-platform-${version}";
 
   src = fetchurl {
-    url = "https://github.com/Pulse-Eight/platform/archive/${version}.tar.gz";
-    sha256 = "1kdmi9b62nky4jrb5519ddnw5n7s7m6qyj7rzhg399f0n6f278vb";
+    url = "https://github.com/Pulse-Eight/platform/archive/p8-platform-${version}.tar.gz";
+    sha256 = "1kslq24p2zams92kc247qcczbxb2n89ykk9jfyiilmwh7qklazp9";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "Platform library for libcec and Kodi addons";
     homepage = "https://github.com/Pulse-Eight/platform";
-    repositories.git = "https://github.com/Pulse-Eight/libcec.git";
+    repositories.git = "https://github.com/Pulse-Eight/platform.git";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.titanous ];


### PR DESCRIPTION
Updated pvr-hts plugin to latest version to work with kodi 17. Had to
update libcec as well, to pick the name change.
